### PR TITLE
Potential fix for code scanning alert no. 71: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,9 @@ name: "Push"
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   Build-Docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rotoku/portfolio/security/code-scanning/71](https://github.com/rotoku/portfolio/security/code-scanning/71)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow that do not have their own `permissions` block. Based on the actions used in the `Build-Docker` job, it only requires read access to repository contents (`contents: read`) to check out the code. The `Scan-Docker-Image` job already has a `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
